### PR TITLE
update -prof Check message

### DIFF
--- a/Cabal/Distribution/PackageDescription/Check.hs
+++ b/Cabal/Distribution/PackageDescription/Check.hs
@@ -624,7 +624,7 @@ checkGhcOptions pkg =
       PackageBuildWarning $
            "'ghc-options: -prof' is not necessary and will lead to problems "
         ++ "when used on a library. Use the configure flag "
-        ++ "--enable-library-profiling and/or --enable-executable-profiling."
+        ++ "--enable-library-profiling and/or --enable-profiling."
 
   , checkFlags ["-o"] $
       PackageBuildWarning $


### PR DESCRIPTION
The flag enable-executable-profiling warns to change it to just enable-profiling. So we'll fix that here too so we don't send people down an old path.
